### PR TITLE
Update makefile.eggnog-mapper

### DIFF
--- a/lib/make/makefile.eggnog-mapper
+++ b/lib/make/makefile.eggnog-mapper
@@ -29,7 +29,7 @@ MAKECALL_EGGNOG_MAPPER             = $(MAKECALL_EGGNOG_MAPPER_VERSION); $(MAKECA
 # *** Targets ***
 
 all.emapper.annotations.tsv: $(subst .faa,.emapper.annotations,$(wildcard *.faa))
-	grep '#query_name' $< | sed 's/#//' > $@
+	grep '#query' $< | sed 's/#//' > $@
 	grep -v '^#' $^ >> $@
 
 %.emapper.annotations: %.faa


### PR DESCRIPTION
Probably due to some update in eggnogmapper now the headers start with '#query' instead of '#query_name', so with '#query_name' grep doesn't find them.