### PR TITLE
Fix CORRECT_FAA to add newline before appending sequences

### DIFF
--- a/lib/make/makefile.phylo
+++ b/lib/make/makefile.phylo
@@ -26,7 +26,7 @@ deleted_sequences: $(wildcard problem_sequences.*)
 REMOVE_RARE = sort -u $(wordlist 2,4,$^) > /tmp/$(basename $@).delete; \
 	grep '>' $< | grep -v -F -f /tmp/$(basename $@).delete | sed 's/.*@//' > $@
 
-CORRECT_FAA = cat $(word 3,$^) > $@; grep -F -A 1 -f $(wordlist 1,2,$^) | grep -v '^--' >> $@
+CORRECT_FAA = cat $(word 3,$^) > $@; printf "\n" >> $@; grep -F -A 1 -f $(wordlist 1,2,$^) | grep -v '^--' >> $@
 
 %.correct_sequences: %.faa deleted_sequences 
 	$(REMOVE_RARE)


### PR DESCRIPTION
CORRECT_FAA was missing a newline after cat, causing the last sequence of interesting.faa to be concatenated with the first appended sequence, introducing illegal characters.